### PR TITLE
新功能（签到薅羊毛/天气预报推送）：依赖缓存

### DIFF
--- a/.github/workflows/daily_sign.yml
+++ b/.github/workflows/daily_sign.yml
@@ -23,6 +23,8 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.12"
+        cache: pip
+        cache-dependency-path: requirements.txt
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/weather_report.yml
+++ b/.github/workflows/weather_report.yml
@@ -24,6 +24,8 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.12"
+        cache: pip
+        cache-dependency-path: requirements.txt
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
## 主要更改

- 启用 `actions/setup-python` 步骤中提供的依赖项缓存功能，显著加速依赖安装过程。

## 示例效果

- [Dragon1573/GithubActionSample 签到薅羊毛 #1](https://github.com/Dragon1573/GithubActionSample/actions/runs/7455888448/job/20285671581)
- [Dragon1573/GithubActionSample 天气预报推送 #3](https://github.com/Dragon1573/GithubActionSample/actions/runs/7455879907/job/20285648306)